### PR TITLE
Allow adding non friends to your chat list (bots, etc)

### DIFF
--- a/lib/facebot.js
+++ b/lib/facebot.js
@@ -359,6 +359,9 @@ Facebot.prototype.respondToCreateChatMessages = function(message) {
     var requiredUsers = [this.user.id, this.authorised_user.id];
 
     // Parse the friend name: "@facebot chat captain planet" becomes "captain planet"
+    var any_chat = message.text.indexOf('chat_any ') != -1;
+    if (any_chat)
+    	message.text = message.text.replace('chat_any ','chat ');
     var friendname = message.text
         .substring(message.text.indexOf('chat') + 'chat'.length)
         .trim();
@@ -368,7 +371,7 @@ Facebot.prototype.respondToCreateChatMessages = function(message) {
             if (!isTruelyPrivate)
                 throw new Error('The channel should only contain you and me.');
         })
-        .then(() => fbUtil.findFBUser(this.facebookApi, friendname))
+        .then(() => fbUtil.findFBUser(this.facebookApi, friendname, any_chat))
         .then(friend => {
             this.channelLinks.push({
                 slack_channel: message.channel,
@@ -439,7 +442,7 @@ Facebot.prototype.dispatchBotCommands = function(message) {
 Facebot.prototype.respondToCommands = function(command, message) {
     if (command === 'list') return this.postListOfLinkedChannels(message);
 
-    if (command === 'chat') return this.respondToCreateChatMessages(message);
+    if (command === 'chat' || command === 'chat_any') return this.respondToCreateChatMessages(message);
 
     if (command == 'unlink') return this.respondToUnlinkCommands(message);
 
@@ -450,6 +453,7 @@ Facebot.prototype.respondToCommands = function(command, message) {
     if (command === 'help') {
         response = '`@facebot help`: See this text\n' +
             '`@facebot chat <friend name>`: Connect a private channel with a facebook friend\n' +
+            '`@facebot chat_any <name>`: Connect a private channel with a facebook friend, non-friend, or bot\n' +
             '`@facebot unlink`: Disconnects the current channel from facebook messages\n' +
             '`@facebot status`: Show facebook connectivity status\n' +
             '`@facebot list`: Shows information about linked chats\n' +


### PR DESCRIPTION
This requires a merge in from facebook-chat-api on 2017-4-11 so make sure to npm install since then for this to work with bots (non-friends will work with any version).